### PR TITLE
Reconnect to DB if connection closed

### DIFF
--- a/scrapy_heroku/spiderqueue.py
+++ b/scrapy_heroku/spiderqueue.py
@@ -38,7 +38,7 @@ class Psycopg2PriorityQueue(object):
         try:
             cursor = self.conn.cursor()
             cursor.execute(q, args)
-        except psycopg2.InterfaceError:
+        except (psycopg2.InterfaceError, psycopg2.OperationalError) as err:
             self.conn = psycopg2.connect(self.conn_string)
             cursor = self.conn.cursor()
             cursor.execute(q, args)

--- a/scrapy_heroku/spiderqueue.py
+++ b/scrapy_heroku/spiderqueue.py
@@ -21,7 +21,10 @@ class Psycopg2PriorityQueue(object):
             'host': url.hostname,
             'port': url.port,
         }
+
         conn_string = ' '.join('%s=%s' % item for item in args.items())
+
+        self.conn_string = conn_string
         self.table = table
         self.conn = psycopg2.connect(conn_string)
         q = "create table if not exists %s " \
@@ -32,14 +35,21 @@ class Psycopg2PriorityQueue(object):
         self.conn.commit()
 
     def _execute(self, q, args=None, results=True):
-        cursor = self.conn.cursor()
-        cursor.execute(q, args)
+        try:
+            cursor = self.conn.cursor()
+            cursor.execute(q, args)
+        except psycopg2.InterfaceError:
+            self.conn = psycopg2.connect(self.conn_string)
+            cursor = self.conn.cursor()
+            cursor.execute(q, args)
+
         if results:
             try:
                 results = list(cursor)
             except psycopg2.ProgrammingError:
                 results = []
         cursor.close()
+
         return results
 
     def put(self, message, priority=0.0):


### PR DESCRIPTION
Fixes issue https://github.com/dmclain/scrapy-heroku/issues/2

When the pg connection is closed and a `psycopg2.InterfaceError` is raised, it will now create a new connection and execute the query.
